### PR TITLE
feat: Implement dynamic event types for teams

### DIFF
--- a/app/Actions/Jetstream/CreateTeam.php
+++ b/app/Actions/Jetstream/CreateTeam.php
@@ -32,6 +32,8 @@ class CreateTeam implements CreatesTeams
             'personal_team' => false,
         ]));
 
+        (new \Database\Seeders\EventTypeSeeder)->run($team->id);
+
         return $team;
     }
 }

--- a/app/Exports/EventsExport.php
+++ b/app/Exports/EventsExport.php
@@ -24,7 +24,7 @@ class EventsExport implements FromQuery, WithHeadings, WithStyles, WithMapping, 
     public $worker;
     public $fromdate;
     public $todate;
-    public $description;
+    public $event_type_id;
     public $observations;
     public $user;
     public $team;
@@ -35,7 +35,7 @@ class EventsExport implements FromQuery, WithHeadings, WithStyles, WithMapping, 
         $this->worker = $params['worker'];
         $this->fromdate = $params['fromdate'];
         $this->todate = $params['todate'];
-        $this->description = $params['description'] == __('All') ? '%' : __($params['description']);
+        $this->event_type_id = $params['event_type_id'] == 'All' ? '%' : $params['event_type_id'];
         $this->user = Auth::user();
         $this->team = $this->user->currentTeam;
     }
@@ -51,7 +51,7 @@ class EventsExport implements FromQuery, WithHeadings, WithStyles, WithMapping, 
             ->when(($this->worker != "%"), fn ($query) => $query->where('users.id', $this->worker))
             ->whereDate('start', '>=', $this->fromdate)
             ->whereDate('end', '<=', $this->todate)
-            ->where('description', 'like', $this->description)
+            ->when(($this->event_type_id != "%"), fn ($query) => $query->where('event_type_id', $this->event_type_id))
             ->orderBy('events.start');
         return $data;
     }

--- a/app/Http/Livewire/AddEvent.php
+++ b/app/Http/Livewire/AddEvent.php
@@ -54,6 +54,8 @@ class AddEvent extends Component
      * @var string
      */
     public $description;
+    public $event_type_id;
+    public $eventTypes;
 
     /**
      * Additional observations about the event.
@@ -104,6 +106,8 @@ class AddEvent extends Component
         $this->start_time = date('H:i:s');
         $this->description = __('Workday');
         $this->observations = '';
+        $this->eventTypes = Auth::user()->currentTeam->eventTypes;
+        $this->event_type_id = $this->eventTypes->first()->id;
         $this->getWorkScheduleHint();
     }
 
@@ -143,6 +147,7 @@ class AddEvent extends Component
             'user_code' => Auth::user()->user_code,
             'description' => $this->description,
             'observations' => $this->observations,
+            'event_type_id' => $this->event_type_id,
             'is_open' => true
         ]);
 

--- a/app/Http/Livewire/EditEvent.php
+++ b/app/Http/Livewire/EditEvent.php
@@ -29,6 +29,7 @@ class EditEvent extends Component
      * @var User $user Holds the user associated with the event.
      */
     public User $user;
+    public $eventTypes;
 
     /**
      * @var array $listeners Listens for emitted events.
@@ -42,6 +43,7 @@ class EditEvent extends Component
         'event.start' => 'required|date',
         'event.end' => 'required|date',
         'event.description' => 'required',
+        'event.event_type_id' => 'required',
         'event.observations' => 'string|max:255|nullable',
     ];
 
@@ -66,6 +68,7 @@ class EditEvent extends Component
     {
         $this->event = $ev;
         $this->user = User::find($ev->user_id);
+        $this->eventTypes = $this->user->currentTeam->eventTypes;
 
         $this->setSuggestedScheduleInfo();
 

--- a/app/Http/Livewire/Numpad.php
+++ b/app/Http/Livewire/Numpad.php
@@ -44,7 +44,7 @@ class Numpad extends Component
         $events = $this->getOpenEventsForUser($user->id);
 
         if ($user) {
-            
+
             // If there are no open events, or the user has specific roles, redirect or emit an event
             if ($events->count() || $user->isTeamAdmin() || $user->isInspector()) {
                 return redirect()->route('events');

--- a/app/Http/Livewire/ReportsComponent.php
+++ b/app/Http/Livewire/ReportsComponent.php
@@ -19,16 +19,16 @@ class ReportsComponent extends Component
     public $worker;
     public $fromdate;
     public $todate;
-    public string $description;
+    public $event_type_id;
     public string $rtype;
     public $rtypes = ["PDF" => "Dompdf", "XLS" => "Xls", "CSV" => "Csv", "ODS" => "Ods", "HTML" => "Html"];
-    public $descriptions = ["All", "Workday", "Pause", "Others"];
+    public $eventTypes;
 
     protected $rules = [
         "worker" => 'required',
         "fromdate" => 'bail|required|date|before_or_equal:todate',
         "todate" => 'required|date|before_or_equal:now',
-        "description" => 'required|string',
+        "event_type_id" => 'required',
         "rtype" => 'required',
     ];
 
@@ -50,7 +50,8 @@ class ReportsComponent extends Component
         $this->worker = $this->user->id;
         $this->fromdate = date('Y-m-01');
         $this->todate = date('Y-m-d');
-        $this->description = 'All';
+        $this->eventTypes = $this->team->eventTypes;
+        $this->event_type_id = 'All';
         $this->rtype = 'PDF';
     }
 
@@ -77,7 +78,7 @@ class ReportsComponent extends Component
             "worker" => $this->worker,
             "fromdate" => $this->fromdate,
             "todate" => $this->todate,
-            "description" => __($this->description),
+            "event_type_id" => $this->event_type_id,
         ];
 
         $this->validate();

--- a/app/Http/Livewire/Teams/EventTypeManager.php
+++ b/app/Http/Livewire/Teams/EventTypeManager.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Http\Livewire\Teams;
+
+use App\Models\EventType;
+use Illuminate\Support\Facades\Gate;
+use Livewire\Component;
+
+class EventTypeManager extends Component
+{
+    public $team;
+    public $eventTypes;
+    public $confirmingEventTypeDeletion = false;
+    public $eventTypeToDelete;
+    public $managingEventType = false;
+    public $eventType;
+
+    protected $rules = [
+        'eventType.name' => 'required|string|max:255',
+        'eventType.color' => 'required|string|max:255',
+        'eventType.observations' => 'nullable|string',
+    ];
+
+    public function mount($team)
+    {
+        $this->team = $team;
+        $this->eventTypes = $team->eventTypes;
+    }
+
+    public function render()
+    {
+        return view('livewire.teams.event-type-manager');
+    }
+
+    public function confirmEventTypeDeletion(EventType $eventType)
+    {
+        $this->confirmingEventTypeDeletion = true;
+        $this->eventTypeToDelete = $eventType;
+    }
+
+    public function deleteEventType()
+    {
+        Gate::forUser(auth()->user())->authorize('delete', $this->eventTypeToDelete);
+
+        $this->eventTypeToDelete->delete();
+
+        $this->eventTypes = $this->team->eventTypes()->get();
+
+        $this->confirmingEventTypeDeletion = false;
+    }
+
+    public function manageEventType(EventType $eventType = null)
+    {
+        $this->managingEventType = true;
+        $this->eventType = $eventType ?? new EventType();
+    }
+
+    public function saveEventType()
+    {
+        $this->validate();
+
+        if (isset($this->eventType->id)) {
+            Gate::forUser(auth()->user())->authorize('update', $this->eventType);
+            $this->eventType->save();
+        } else {
+            Gate::forUser(auth()->user())->authorize('create', [EventType::class, $this->team]);
+            $this->team->eventTypes()->save($this->eventType);
+        }
+
+        $this->eventTypes = $this->team->eventTypes()->get();
+        $this->managingEventType = false;
+    }
+}

--- a/app/Models/EventType.php
+++ b/app/Models/EventType.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class EventType extends Model
+{
+    //
+}

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -26,16 +26,6 @@ class UserFactory extends Factory
     public function definition()
     {
         return [
-            'user_code' => '12345678',
-            'name' => '***REMOVED***',
-            'family_name1' => '***REMOVED***',
-            'family_name2' => '***REMOVED***',
-            'email' => '***REMOVED***',
-            'email_verified_at' => now(),
-            'password' => Hash::make('test_passwd'), // password
-            'remember_token' => Str::random(10),
-        ];
-        /* return [
             'user_code' => $this->faker->randomNumber($nbDigits = 8),
             'name' => $this->faker->name(),
             'family_name1' => $this->faker->firstName(),
@@ -44,7 +34,7 @@ class UserFactory extends Factory
             'email_verified_at' => now(),
             'password' => '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', // password
             'remember_token' => Str::random(10),
-        ]; */
+        ];
     }
 
     /**

--- a/database/migrations/2019_12_14_000001_create_personal_access_tokens_table.php
+++ b/database/migrations/2019_12_14_000001_create_personal_access_tokens_table.php
@@ -20,6 +20,7 @@ class CreatePersonalAccessTokensTable extends Migration
             $table->string('token', 64)->unique();
             $table->text('abilities')->nullable();
             $table->timestamp('last_used_at')->nullable();
+            $table->timestamp('expires_at')->nullable();
             $table->timestamps();
         });
     }

--- a/database/migrations/2022_05_17_180450_create_events_table.php
+++ b/database/migrations/2022_05_17_180450_create_events_table.php
@@ -19,6 +19,7 @@ return new class extends Migration
             $table->dateTime('start');
             $table->dateTime('end')->nullable();
             $table->string('description')->nullable();
+            $table->foreignId('event_type_id')->nullable()->constrained()->onDelete('set null');
             $table->boolean('is_open');
             $table->timestamps();
 

--- a/database/migrations/2025_09_04_200523_create_event_types_table.php
+++ b/database/migrations/2025_09_04_200523_create_event_types_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('event_types', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('team_id')->constrained()->cascadeOnDelete();
+            $table->string('name');
+            $table->text('observations')->nullable();
+            $table->string('color');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('event_types');
+    }
+};

--- a/database/seeders/EventTypeSeeder.php
+++ b/database/seeders/EventTypeSeeder.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\EventType;
+use Illuminate\Database\Seeder;
+
+class EventTypeSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run($teamId): void
+    {
+        $eventTypes = [
+            [
+                'name' => 'Jornada laboral',
+                'color' => '#0284c7',
+                'observations' => 'Horas trabajadas en un día normal.'
+            ],
+            [
+                'name' => 'Asuntos propios',
+                'color' => '#eab308',
+                'observations' => 'Días de permiso para asuntos personales.'
+            ],
+            [
+                'name' => 'Vacaciones',
+                'color' => '#22c55e',
+                'observations' => 'Días de vacaciones anuales.'
+            ],
+            [
+                'name' => 'Evento especial',
+                'color' => '#8b5cf6',
+                'observations' => 'Eventos especiales como bodas, bautizos, etc.'
+            ],
+        ];
+
+        foreach ($eventTypes as $eventType) {
+            EventType::create([
+                'team_id' => $teamId,
+                'name' => $eventType['name'],
+                'color' => $eventType['color'],
+                'observations' => $eventType['observations'],
+            ]);
+        }
+    }
+}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -21,8 +21,8 @@
         <env name="APP_ENV" value="testing"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="CACHE_DRIVER" value="array"/>
-        <!-- <env name="DB_CONNECTION" value="sqlite"/> -->
-        <!-- <env name="DB_DATABASE" value=":memory:"/> -->
+        <env name="DB_CONNECTION" value="sqlite"/>
+        <env name="DB_DATABASE" value=":memory:"/>
         <env name="MAIL_MAILER" value="array"/>
         <env name="QUEUE_CONNECTION" value="sync"/>
         <env name="SESSION_DRIVER" value="array"/>

--- a/resources/views/livewire/events/add-event.blade.php
+++ b/resources/views/livewire/events/add-event.blade.php
@@ -23,13 +23,13 @@
             </div>
 
             <div class="mb-4">
-                <x-jet-label value="{{ __('Description') }}" class="required" />
-                <select class="sl-select" required wire:model="description" name="description">
-                    <option value="{{ __('Workday') }}" selected="selected">{{ __('Workday') }}</option>
-                    <option value="{{ __('Pause') }}">{{ __('Pause') }}</option>
-                    <option value="{{ __('Others') }}">{{ __('Others') }}</option>
+                <x-jet-label value="{{ __('Event Type') }}" class="required" />
+                <select class="sl-select" required wire:model="event_type_id" name="event_type_id">
+                    @foreach($eventTypes as $eventType)
+                        <option value="{{ $eventType->id }}">{{ $eventType->name }}</option>
+                    @endforeach
                 </select>
-                <x-jet-input-error for='description' />
+                <x-jet-input-error for='event_type_id' />
             </div>
 
             <div class="mx-auto mb-4">

--- a/resources/views/livewire/events/edit-event.blade.php
+++ b/resources/views/livewire/events/edit-event.blade.php
@@ -23,14 +23,13 @@
             {{-- end-datepicker --}}
 
             <div class="mb-4">
-                <x-jet-label value="{{ __('Description') }}" />
-                <select class="sl-select" wire:model.defer="event.description" name="event.description" required>
-                    {{-- TODO Integrate causes as new model --}}
-                    <option value="{{ __('Workday') }}" selected="selected">{{ __('Workday') }}</option>
-                    <option value="{{ __('Pause') }}">{{ __('Pause') }}</option>
-                    <option value="{{ __('Others') }}">{{ __('Others') }}</option>
+                <x-jet-label value="{{ __('Event Type') }}" />
+                <select class="sl-select" wire:model.defer="event.event_type_id" name="event.event_type_id" required>
+                    @foreach($eventTypes as $eventType)
+                        <option value="{{ $eventType->id }}">{{ $eventType->name }}</option>
+                    @endforeach
                 </select>
-                <x-jet-input-error for='event.description' />
+                <x-jet-input-error for='event.event_type_id' />
             </div>
 
             <div class="mx-auto mb-4">

--- a/resources/views/livewire/reports/reports.blade.php
+++ b/resources/views/livewire/reports/reports.blade.php
@@ -51,15 +51,16 @@
             </div>
 
             <div>
-                <x-jet-label value="{{ __('Description') }}" />
-                <select class="form-control pt-1 h-8 whitespace-nowrap" wire:model='description'>
-                    $@foreach ($descriptions as $description)
-                        <option value="{{ $description }}">
-                            {{ __($description) }}
+                <x-jet-label value="{{ __('Event Type') }}" />
+                <select class="form-control pt-1 h-8 whitespace-nowrap" wire:model='event_type_id'>
+                    <option value="All">{{ __('All') }}</option>
+                    @foreach ($eventTypes as $eventType)
+                        <option value="{{ $eventType->id }}">
+                            {{ $eventType->name }}
                         </option>
                     @endforeach
                 </select>
-                <x-jet-input-error for='description' />
+                <x-jet-input-error for='event_type_id' />
             </div>
 
             <div>

--- a/resources/views/livewire/teams/event-type-manager.blade.php
+++ b/resources/views/livewire/teams/event-type-manager.blade.php
@@ -1,0 +1,111 @@
+<div>
+    <x-jet-action-section>
+        <x-slot name="title">
+            {{ __('Tipos de evento') }}
+        </x-slot>
+
+        <x-slot name="description">
+            {{ __('Aquí puedes gestionar los tipos de evento de tu equipo.') }}
+        </x-slot>
+
+        <x-slot name="content">
+            <div class="flex items-center justify-end">
+                <x-jet-button wire:click="manageEventType">
+                    {{ __('Añadir tipo de evento') }}
+                </x-jet-button>
+            </div>
+
+            <div class="mt-6">
+                <table class="min-w-full divide-y divide-gray-200">
+                    <thead class="bg-gray-50">
+                        <tr>
+                            <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                                {{ __('Nombre') }}
+                            </th>
+                            <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                                {{ __('Color') }}
+                            </th>
+                            <th scope="col" class="relative px-6 py-3">
+                                <span class="sr-only">{{ __('Acciones') }}</span>
+                            </th>
+                        </tr>
+                    </thead>
+                    <tbody class="bg-white divide-y divide-gray-200">
+                        @foreach ($eventTypes as $eventType)
+                            <tr>
+                                <td class="px-6 py-4 whitespace-nowrap">
+                                    <div class="text-sm text-gray-900">{{ $eventType->name }}</div>
+                                </td>
+                                <td class="px-6 py-4 whitespace-nowrap">
+                                    <div class="w-6 h-6 rounded-full" style="background-color: {{ $eventType->color }}"></div>
+                                </td>
+                                <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+                                    <button wire:click="manageEventType({{ $eventType->id }})" class="text-indigo-600 hover:text-indigo-900">{{ __('Editar') }}</button>
+                                    <button wire:click="confirmEventTypeDeletion({{ $eventType->id }})" class="ml-2 text-red-600 hover:text-red-900">{{ __('Eliminar') }}</button>
+                                </td>
+                            </tr>
+                        @endforeach
+                    </tbody>
+                </table>
+            </div>
+        </x-slot>
+    </x-jet-action-section>
+
+    <!-- Delete Event Type Confirmation Modal -->
+    <x-jet-confirmation-modal wire:model="confirmingEventTypeDeletion">
+        <x-slot name="title">
+            {{ __('Eliminar tipo de evento') }}
+        </x-slot>
+
+        <x-slot name="content">
+            {{ __('¿Estás seguro de que quieres eliminar este tipo de evento?') }}
+        </x-slot>
+
+        <x-slot name="footer">
+            <x-jet-secondary-button wire:click="$toggle('confirmingEventTypeDeletion')" wire:loading.attr="disabled">
+                {{ __('Cancelar') }}
+            </x-jet-secondary-button>
+
+            <x-jet-danger-button class="ml-2" wire:click="deleteEventType" wire:loading.attr="disabled">
+                {{ __('Eliminar') }}
+            </x-jet-danger-button>
+        </x-slot>
+    </x-jet-confirmation-modal>
+
+    <!-- Manage Event Type Modal -->
+    <x-jet-dialog-modal wire:model="managingEventType">
+        <x-slot name="title">
+            {{ isset($this->eventType->id) ? __('Editar tipo de evento') : __('Añadir tipo de evento') }}
+        </x-slot>
+
+        <x-slot name="content">
+            <div class="space-y-4">
+                <div>
+                    <x-jet-label for="name" value="{{ __('Nombre') }}" />
+                    <x-jet-input id="name" type="text" class="mt-1 block w-full" wire:model.defer="eventType.name" />
+                    <x-jet-input-error for="eventType.name" class="mt-2" />
+                </div>
+                <div>
+                    <x-jet-label for="color" value="{{ __('Color') }}" />
+                    <x-jet-input id="color" type="color" class="mt-1 block w-full" wire:model.defer="eventType.color" />
+                    <x-jet-input-error for="eventType.color" class="mt-2" />
+                </div>
+                <div>
+                    <x-jet-label for="observations" value="{{ __('Observaciones') }}" />
+                    <textarea id="observations" class="mt-1 block w-full border-gray-300 focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50 rounded-md shadow-sm" wire:model.defer="eventType.observations"></textarea>
+                    <x-jet-input-error for="eventType.observations" class="mt-2" />
+                </div>
+            </div>
+        </x-slot>
+
+        <x-slot name="footer">
+            <x-jet-secondary-button wire:click="$toggle('managingEventType')" wire:loading.attr="disabled">
+                {{ __('Cancelar') }}
+            </x-jet-secondary-button>
+
+            <x-jet-button class="ml-2" wire:click="saveEventType" wire:loading.attr="disabled">
+                {{ __('Guardar') }}
+            </x-jet-button>
+        </x-slot>
+    </x-jet-dialog-modal>
+</div>

--- a/resources/views/teams/show.blade.php
+++ b/resources/views/teams/show.blade.php
@@ -11,6 +11,12 @@
 
             @livewire('teams.team-member-manager', ['team' => $team])
 
+            <x-jet-section-border />
+
+            <div class="mt-10 sm:mt-0">
+                @livewire('teams.event-type-manager', ['team' => $team])
+            </div>
+
             @if (Gate::check('delete', $team) && ! $team->personal_team)
                 <x-jet-section-border />
 


### PR DESCRIPTION
- Create EventType model and migration.
- Create a seeder to populate the event types for new teams.
- Modify the CreateTeam action to call the seeder.
- Create a Livewire component to manage the event types (CRUD).
- Integrate the new component into the team settings page.
- Update the add and edit event modals to use the new dynamic event types.
- Update the reports component to use the new dynamic event types.